### PR TITLE
URL Error, missing data for 平成30年, fixes #1

### DIFF
--- a/tools/download.sh
+++ b/tools/download.sh
@@ -12,7 +12,7 @@ mkdir -p ${CACHE_DIR}
 rm -f ${OUTPUT}
 
 for no in `seq -w 1000 1000 47000` ; do
-  url="http://nlftp.mlit.go.jp/isj/dls/data/12.0b/${no}-12.0b.zip"
+  url="https://nlftp.mlit.go.jp/isj/dls/data/11.0b/${no}-11.0b.zip"
   zip=${CACHE_DIR}/${no}.zip
   if [ ! -e "${zip}" ] ; then
     curl $url > ${zip}


### PR DESCRIPTION
There seems to be no data for 平成30年 (`12.0b`), but there exists data for 平成29年 (`11.0b`).
Using  `https` seems to be also necessary.