### PR TITLE
ESLint を追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
     "rules": {
         "indent": [
             "error",
-            4
+            2
         ],
         "linebreak-style": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es2020": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 11
+    },
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,34 +1,34 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const commandLineArgs = require('command-line-args');
-const commandLineUsage = require('command-line-usage');
+const fs = require("fs");
+const commandLineArgs = require("command-line-args");
+const commandLineUsage = require("command-line-usage");
 const enrichment = require("../main");
 
 const optionDefinitions = [{
-  name: 'help',
-  alias: 'h',
+  name: "help",
+  alias: "h",
   type: Boolean,
-  description: 'このヘルプを表示します'
+  description: "このヘルプを表示します"
 }, {
-  name: 'file',
-  alias: 'f',
+  name: "file",
+  alias: "f",
   type: String,
   defaultOption: true,
-  typeLabel: '{underline file}',
-  description: '変換対象とする JSON ファイル'
+  typeLabel: "{underline file}",
+  description: "変換対象とする JSON ファイル"
 }, {
-  name: 'string',
-  alias: 's',
+  name: "string",
+  alias: "s",
   type: String,
-  typeLabel: '{underline string}',
-  description: '変換対象とする住所文字列',
+  typeLabel: "{underline string}",
+  description: "変換対象とする住所文字列",
 }, {
-  name: 'indent',
-  alias: 'i',
+  name: "indent",
+  alias: "i",
   type: Number,
-  typeLabel: '{underline number}',
-  description: '出力する JSON のインデント (default 2)',
+  typeLabel: "{underline number}",
+  description: "出力する JSON のインデント (default 2)",
   defaultValue: 2
 }];
 
@@ -36,32 +36,32 @@ const options = commandLineArgs(optionDefinitions);
 
 if (options.help) {
   const usage = commandLineUsage([{
-    header: 'imi-enrichment-address',
-    content: '住所文字列をもとに住所型・場所型の情報を補完します'
+    header: "imi-enrichment-address",
+    content: "住所文字列をもとに住所型・場所型の情報を補完します"
   }, {
-    header: 'オプション',
+    header: "オプション",
     optionList: optionDefinitions
   }, {
-    header: '実行例',
+    header: "実行例",
     content: [{
-        desc: 'ヘルプの表示',
-        example: '$ imi-enrichment-address -h'
-      },
-      {
-        desc: '文字列の処理',
-        example: '$ imi-enrichment-address -s 霞が関2'
-      },
-      {
-        desc: 'ファイルの処理',
-        example: '$ imi-enrichment-address input.json'
-      },
-      {
-        desc: '標準入力の処理',
-        example: '$ cat input.json | imi-enrichment-address'
-      }
+      desc: "ヘルプの表示",
+      example: "$ imi-enrichment-address -h"
+    },
+    {
+      desc: "文字列の処理",
+      example: "$ imi-enrichment-address -s 霞が関2"
+    },
+    {
+      desc: "ファイルの処理",
+      example: "$ imi-enrichment-address input.json"
+    },
+    {
+      desc: "標準入力の処理",
+      example: "$ cat input.json | imi-enrichment-address"
+    }
     ]
   }]);
-  console.log(usage)
+  console.log(usage);
 } else if (options.string) {
   enrichment(options.string).then(json => {
     console.log(JSON.stringify(json, null, options.indent));
@@ -73,10 +73,10 @@ if (options.help) {
   });
 } else {
   let buffer = "";
-  process.stdin.setEncoding('utf-8');
-  process.stdin.on('data', chunk => {
+  process.stdin.setEncoding("utf-8");
+  process.stdin.on("data", chunk => {
     buffer += chunk;
-  }).on('end', () => {
+  }).on("end", () => {
     const input = JSON.parse(buffer);
     enrichment(input).then(json => {
       console.log(JSON.stringify(json, null, options.indent));

--- a/bin/server.js
+++ b/bin/server.js
@@ -16,7 +16,7 @@ const server = http.createServer((req, res) => {
       "Content-Type": "text/html; charset=utf-8",
       "Access-Control-Allow-Origin": "*"
     });
-    res.end(require('fs').readFileSync(__dirname + "/server.html", "utf-8"));
+    res.end(require("fs").readFileSync(__dirname + "/server.html", "utf-8"));
     return;
   }
   if (req.method !== "POST") {

--- a/lib/find.js
+++ b/lib/find.js
@@ -1,4 +1,4 @@
-const util = require('./util');
+const util = require("./util");
 
 // tree の構造変更
 const tree = (function(src) {
@@ -16,7 +16,7 @@ const tree = (function(src) {
         label: key.replace(/^[0-9]+/, "")
       };
 
-      if (typeof val === 'object') {
+      if (typeof val === "object") {
         obj.children = dig(val).map(child => {
           child.parent = obj;
           if (child.code.length !== 5) {
@@ -24,9 +24,9 @@ const tree = (function(src) {
           }
           return child;
         });
-      } else if (typeof val === 'number') {
+      } else if (typeof val === "number") {
         obj.chome = val;
-      } else if (typeof val === 'string') {
+      } else if (typeof val === "string") {
         moved[key] = val;
       }
 
@@ -45,7 +45,7 @@ const tree = (function(src) {
 
   return root;
 
-})(require('./tree.json'));
+})(require("./tree.json"));
 
 
 // 1. 市区町村の特定
@@ -155,7 +155,7 @@ module.exports = function(address) {
     return {
       code: hit.code + (hit.code.length === 9 ? "000" : ""),
       tail: tail
-    }
+    };
   };
 
   // 市区町村にヒットする場合

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,7 +31,7 @@ const deepStrictEqual = function(expected, actual) {
     return true;
   }
 
-  if (typeof expected === 'object') {
+  if (typeof expected === "object") {
     const k1 = Object.keys(expected);
     const k2 = Object.keys(actual);
     if (k1.length !== k2.length) return false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,38 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "abstract-leveldown": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
@@ -12,6 +44,30 @@
         "level-concat-iterator": "~2.0.0",
         "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {
@@ -54,6 +110,12 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -74,6 +136,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
@@ -214,6 +282,28 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -243,6 +333,12 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "deferred-leveldown": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
@@ -267,11 +363,29 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.5.tgz",
+      "integrity": "sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -316,11 +430,244 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.3.0.tgz",
+      "integrity": "sha512-dJMVXwfU5PT1cj2Nv2VPPrKahKTGdX+5Dh0Q3YuKt+Y2UhdL2YbzsVaBMyG9HC0tBismlv/r1+eZqs6SMIV38Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.0",
+        "eslint-utils": "^2.0.0",
+        "eslint-visitor-keys": "^1.2.0",
+        "espree": "^7.1.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.2.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.2.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
     },
     "find-replace": {
       "version": "3.0.0",
@@ -348,6 +695,23 @@
         "is-buffer": "~2.0.3"
       }
     },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -358,6 +722,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "get-caller-file": {
@@ -384,6 +754,24 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
       }
     },
     "growl": {
@@ -416,6 +804,28 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
@@ -451,11 +861,26 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-regex": {
       "version": "1.0.5",
@@ -481,6 +906,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -490,6 +921,18 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "level-concat-iterator": {
       "version": "2.0.1",
@@ -542,6 +985,16 @@
         "level-iterator-stream": "~4.0.0",
         "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "locate-path": {
@@ -640,6 +1093,12 @@
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -704,6 +1163,20 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -728,6 +1201,15 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -740,16 +1222,40 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "readable-stream": {
       "version": "3.4.0",
@@ -766,6 +1272,12 @@
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -777,6 +1289,21 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "safe-buffer": {
       "version": "5.2.0",
@@ -794,6 +1321,32 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -885,6 +1438,46 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "table-layout": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.0.tgz",
@@ -903,10 +1496,31 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
     "typical": {
@@ -914,10 +1528,25 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",
@@ -942,6 +1571,12 @@
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrapjs": {
       "version": "4.0.0",
@@ -1003,6 +1638,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.2.0",
+    "eslint": "^7.3.0",
     "mocha": "^6.2.3",
     "node-fetch": "^2.6.0"
   },

--- a/test/test-bangou.js
+++ b/test/test-bangou.js
@@ -1,5 +1,5 @@
 const bangou = require("../lib/bangou");
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
 const data = {
   "": {},
@@ -14,8 +14,8 @@ const data = {
   }
 };
 
-describe('imi-enrichment-address#bangou', function() {
-  describe('番地・号なし', function() {
+describe("imi-enrichment-address#bangou", function() {
+  describe("番地・号なし", function() {
     it("空白", () => {
       expect(bangou("")).deep.equal({});
     });
@@ -23,7 +23,7 @@ describe('imi-enrichment-address#bangou', function() {
       expect(bangou("ビル名")).deep.equal({});
     });
   });
-  describe('番地のみ', function() {
+  describe("番地のみ", function() {
     it("半角", () => {
       expect(bangou("12345")).deep.equal({
         "番地": "12345"
@@ -58,7 +58,7 @@ describe('imi-enrichment-address#bangou', function() {
       });
     });
   });
-  describe('番地号', function() {
+  describe("番地号", function() {
     it("半角", () => {
       expect(bangou("103-45")).deep.equal({
         "番地": "103",

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,5 +1,5 @@
-const expect = require('chai').expect;
-const spawn = require('child_process').spawn;
+const expect = require("chai").expect;
+const spawn = require("child_process").spawn;
 const fs = require("fs");
 const spec = __dirname + "/../spec";
 
@@ -8,15 +8,15 @@ function cli(options, stdin) {
   const cmd = ["bin/cli.js"].concat(options || []);
   return new Promise(resolve => {
     const child = spawn("node", cmd);
-    child.stdout.setEncoding('utf-8');
-    child.stdout.on('data', (data) => {
+    child.stdout.setEncoding("utf-8");
+    child.stdout.on("data", (data) => {
       res += data;
     });
-    child.on('close', (code) => {
+    child.on("close", (code) => {
       resolve(res);
     });
     if (stdin) {
-      child.stdin.setEncoding('utf-8');
+      child.stdin.setEncoding("utf-8");
       child.stdin.write(stdin);
       child.stdin.end();
     }
@@ -25,7 +25,7 @@ function cli(options, stdin) {
 
 const samples = JSON.parse(fs.readFileSync(`${spec}/001-io.json`, "UTF-8"));
 
-describe('imi-enrichment-addressn#cli', () => {
+describe("imi-enrichment-addressn#cli", () => {
 
   const tempfile = `tmp.${(new Date()).getTime()}.json`;
 
@@ -38,7 +38,7 @@ describe('imi-enrichment-addressn#cli', () => {
     fs.unlinkSync(tempfile);
   });
 
-  describe('options', () => {
+  describe("options", () => {
 
     it("-h", (done) => {
       cli(["-h"]).then(res => {
@@ -135,7 +135,7 @@ describe('imi-enrichment-addressn#cli', () => {
         const json = JSON.parse(fs.readFileSync(`${spec}/${file}`, "UTF-8"));
         json.forEach(a => {
           it(a.name, done => {
-            const promise = typeof a.input === 'string' ? cli(["-s", a.input]) : cli(null, JSON.stringify(a.input));
+            const promise = typeof a.input === "string" ? cli(["-s", a.input]) : cli(null, JSON.stringify(a.input));
             promise.then(res => {
               try {
                 expect(JSON.parse(res)).deep.equal(a.output);

--- a/test/test-find.js
+++ b/test/test-find.js
@@ -1,5 +1,5 @@
 const find = require("../lib/find");
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
 const data = {
   "三軒茶屋二丁目": {
@@ -118,7 +118,7 @@ const data = {
   }
 };
 
-describe('imi-enrichment-address#find', function() {
+describe("imi-enrichment-address#find", function() {
   Object.keys(data).forEach(label => {
     const code = data[label];
     it(label, () => {

--- a/test/test-format.js
+++ b/test/test-format.js
@@ -1,8 +1,8 @@
-const expect = require('chai').expect;
-const levelup = require('levelup');
-const leveldown = require('leveldown');
+const expect = require("chai").expect;
+const levelup = require("levelup");
+const leveldown = require("leveldown");
 
-describe('imi-enrichment-address#format', function() {
+describe("imi-enrichment-address#format", function() {
 
   let db;
 
@@ -57,43 +57,43 @@ describe('imi-enrichment-address#format', function() {
         expect(JSON.parse(str)).deep.equal({
           "@context": "https://imi.go.jp/ns/core/context.jsonld",
           "@graph": [{
-              "@type": "住所型",
-              "メタデータ": {
-                "@type": "文書型",
-                "日付": [{
-                    "@type": "日付型",
-                    "標準型日付": "1999-04-01",
-                    "種別": "施行"
-                  },
-                  {
-                    "@type": "日付型",
-                    "標準型日付": "2019-05-01",
-                    "種別": "廃止"
-                  }
-                ]
+            "@type": "住所型",
+            "メタデータ": {
+              "@type": "文書型",
+              "日付": [{
+                "@type": "日付型",
+                "標準型日付": "1999-04-01",
+                "種別": "施行"
               },
-              "市区町村": "篠山市",
-              "市区町村コード": "http://data.e-stat.go.jp/lod/sac/C28221",
-              "表記": "兵庫県篠山市",
-              "都道府県": "兵庫県",
-              "都道府県コード": "http://data.e-stat.go.jp/lod/sac/C28000"
+              {
+                "@type": "日付型",
+                "標準型日付": "2019-05-01",
+                "種別": "廃止"
+              }
+              ]
             },
-            {
-              "@type": "住所型",
-              "メタデータ": {
-                "@type": "文書型",
-                "日付": {
-                  "@type": "日付型",
-                  "標準型日付": "2019-05-01",
-                  "種別": "施行"
-                },
+            "市区町村": "篠山市",
+            "市区町村コード": "http://data.e-stat.go.jp/lod/sac/C28221",
+            "表記": "兵庫県篠山市",
+            "都道府県": "兵庫県",
+            "都道府県コード": "http://data.e-stat.go.jp/lod/sac/C28000"
+          },
+          {
+            "@type": "住所型",
+            "メタデータ": {
+              "@type": "文書型",
+              "日付": {
+                "@type": "日付型",
+                "標準型日付": "2019-05-01",
+                "種別": "施行"
               },
-              "市区町村": "丹波篠山市",
-              "市区町村コード": "http://data.e-stat.go.jp/lod/sac/C28221",
-              "表記": "兵庫県丹波篠山市",
-              "都道府県": "兵庫県",
-              "都道府県コード": "http://data.e-stat.go.jp/lod/sac/C28000"
-            }
+            },
+            "市区町村": "丹波篠山市",
+            "市区町村コード": "http://data.e-stat.go.jp/lod/sac/C28221",
+            "表記": "兵庫県丹波篠山市",
+            "都道府県": "兵庫県",
+            "都道府県コード": "http://data.e-stat.go.jp/lod/sac/C28000"
+          }
           ]
         });
         done();
@@ -118,15 +118,15 @@ describe('imi-enrichment-address#format', function() {
             "メタデータ": {
               "@type": "文書型",
               "日付": [{
-                  "@type": "日付型",
-                  "種別": "施行",
-                  "標準型日付": "1970-04-01"
-                },
-                {
-                  "@type": "日付型",
-                  "種別": "廃止",
-                  "標準型日付": "2001-05-01"
-                }
+                "@type": "日付型",
+                "種別": "施行",
+                "標準型日付": "1970-04-01"
+              },
+              {
+                "@type": "日付型",
+                "種別": "廃止",
+                "標準型日付": "2001-05-01"
+              }
               ],
               "参照": {
                 "@type": "参照型",
@@ -163,15 +163,15 @@ describe('imi-enrichment-address#format', function() {
             "メタデータ": {
               "@type": "文書型",
               "日付": [{
-                  "@type": "日付型",
-                  "種別": "施行",
-                  "標準型日付": "1970-04-01"
-                },
-                {
-                  "@type": "日付型",
-                  "種別": "廃止",
-                  "標準型日付": "2006-03-01"
-                }
+                "@type": "日付型",
+                "種別": "施行",
+                "標準型日付": "1970-04-01"
+              },
+              {
+                "@type": "日付型",
+                "種別": "廃止",
+                "標準型日付": "2006-03-01"
+              }
               ],
               "参照": {
                 "@type": "参照型",
@@ -213,15 +213,15 @@ describe('imi-enrichment-address#format', function() {
             "メタデータ": {
               "@type": "文書型",
               "日付": [{
-                  "@type": "日付型",
-                  "種別": "施行",
-                  "標準型日付": "1970-04-01"
-                },
-                {
-                  "@type": "日付型",
-                  "種別": "廃止",
-                  "標準型日付": "2001-01-21"
-                }
+                "@type": "日付型",
+                "種別": "施行",
+                "標準型日付": "1970-04-01"
+              },
+              {
+                "@type": "日付型",
+                "種別": "廃止",
+                "標準型日付": "2001-01-21"
+              }
               ],
               "参照": {
                 "@type": "参照型",

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -1,15 +1,15 @@
 const enrich = require("../main");
-const expect = require('chai').expect;
-const fs = require('fs');
+const expect = require("chai").expect;
+const fs = require("fs");
 const spec = __dirname + "/../spec";
 
 
-describe('imi-enrichment-address#main', function() {
+describe("imi-enrichment-address#main", function() {
 
   describe("spec", function() {
     fs.readdirSync(spec).filter(file => file.match(/json$/)).forEach(file => {
       describe(file, function() {
-        const json = JSON.parse(fs.readFileSync(`${spec}/${file}`, "UTF-8"))
+        const json = JSON.parse(fs.readFileSync(`${spec}/${file}`, "UTF-8"));
         json.forEach(a => {
           it(a.name, function(done) {
             enrich(a.input).then(json => {

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,5 +1,5 @@
-const expect = require('chai').expect;
-const spawn = require('child_process').spawn;
+const expect = require("chai").expect;
+const spawn = require("child_process").spawn;
 const fetch = require("node-fetch");
 
 const fs = require("fs");
@@ -8,14 +8,14 @@ const spec = __dirname + "/../spec";
 const PORT = "37564";
 const ENDPOINT = `http://localhost:${PORT}`;
 
-describe('imi-enrichment-address#server', () => {
+describe("imi-enrichment-address#server", () => {
 
   let server = null;
 
   before((done) => {
     server = spawn("node", ["bin/server.js", PORT]);
     let initialized = false;
-    server.stdout.on('data', (data) => {
+    server.stdout.on("data", (data) => {
       if (!initialized) {
         initialized = true;
         done();
@@ -27,7 +27,7 @@ describe('imi-enrichment-address#server', () => {
     server.kill();
   });
 
-  describe('server', () => {
+  describe("server", () => {
     it("GET リクエストに対して 200 OK を返すこと", (done) => {
       try {
         fetch(ENDPOINT).then(res => {
@@ -71,8 +71,8 @@ describe('imi-enrichment-address#server', () => {
         method: "POST",
         body: "hello, world",
         headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
+          "Accept": "application/json",
+          "Content-Type": "application/json"
         }
       }).then(res => {
         try {
@@ -90,8 +90,8 @@ describe('imi-enrichment-address#server', () => {
         method: "POST",
         body: "{}",
         headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
+          "Accept": "application/json",
+          "Content-Type": "application/json"
         }
       }).then(res => {
         try {
@@ -111,14 +111,14 @@ describe('imi-enrichment-address#server', () => {
         const json = JSON.parse(fs.readFileSync(`${spec}/${file}`, "UTF-8"));
         json.forEach(a => {
           it(a.name, done => {
-            const body = typeof a.input === 'object' ? JSON.stringify(a.input) : a.input;
+            const body = typeof a.input === "object" ? JSON.stringify(a.input) : a.input;
 
             fetch(ENDPOINT, {
               method: "POST",
               body: body,
               headers: {
-                'Accept': 'application/json',
-                'Content-Type': typeof a.input === 'object' ? 'application/json' : 'text/plain'
+                "Accept": "application/json",
+                "Content-Type": typeof a.input === "object" ? "application/json" : "text/plain"
               }
             }).then(res => res.json()).then(json => {
               try {

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -1,18 +1,18 @@
 const util = require("../lib/util");
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
-describe('util', function() {
-  it('#z2h', () => {
+describe("util", function() {
+  it("#z2h", () => {
     expect(util.z2h("０１２３４５６７８９０１２３４５６７８９")).to.equal("01234567890123456789");
   });
-  it('#h2z', () => {
+  it("#h2z", () => {
     expect(util.h2z("01234567890123456789")).to.equal("０１２３４５６７８９０１２３４５６７８９");
   });
-  it('#k2h', () => {
+  it("#k2h", () => {
     expect(util.k2h("〇一二三四五六七八九〇一二三四五六七八九")).to.equal("01234567890123456789");
   });
 
-  it('#j2h', () => {
+  it("#j2h", () => {
     expect(util.j2h("零")).to.equal("0");
     expect(util.j2h("一")).to.equal("1");
     expect(util.j2h("二")).to.equal("2");
@@ -107,7 +107,7 @@ describe('util', function() {
     expect(util.j2h("一千五百")).to.equal("1500");
   });
 
-  it('#h2j', () => {
+  it("#h2j", () => {
     expect(util.h2j("0")).to.equal("零");
     expect(util.h2j("1")).to.equal("一");
     expect(util.h2j("2")).to.equal("二");

--- a/tools/format.js
+++ b/tools/format.js
@@ -1,8 +1,8 @@
-const readline = require('readline');
-const fs = require('fs');
+const readline = require("readline");
+const fs = require("fs");
 
-const levelup = require('levelup');
-const leveldown = require('leveldown');
+const levelup = require("levelup");
+const leveldown = require("leveldown");
 const db = levelup(leveldown(__dirname + "/../db"));
 const promises = [];
 
@@ -196,10 +196,10 @@ const latests = {};
 
 readline.createInterface({
   input: process.stdin
-}).on('line', (line) => {
+}).on("line", (line) => {
   const col = line.trim().replace(/"/g, "").split(",");
   if (col.length !== 10) return;
-  if (col[0] === '都道府県コード') return;
+  if (col[0] === "都道府県コード") return;
 
   const pref_code = col[0];
   const city_code = col[2];
@@ -242,7 +242,7 @@ readline.createInterface({
 
   promises.push(db.put(name_code, JSON.stringify(json)));
 
-}).on('close', () => {
+}).on("close", () => {
 
   Promise.all(promises).then(() => {
     console.error("done");

--- a/tools/tree.js
+++ b/tools/tree.js
@@ -1,6 +1,6 @@
-const readline = require('readline');
-const fs = require('fs');
-const simplify = require('../lib/util').simplify;
+const readline = require("readline");
+const fs = require("fs");
+const simplify = require("../lib/util").simplify;
 
 const chome = [
   "〇", "一", "二", "三", "四", "五", "六", "七", "八", "九",
@@ -73,7 +73,7 @@ Object.values(map).forEach(e => {
 
 readline.createInterface({
   input: process.stdin
-}).on('line', (line) => {
+}).on("line", (line) => {
   const col = simplify(line).trim().replace(/"/g, "").split(",");
   if (col.length !== 10) return;
   const pref_code = col[0];
@@ -118,7 +118,7 @@ readline.createInterface({
     x.max = Math.max(x.max, parseInt(lower));
   });
 
-}).on('close', () => {
+}).on("close", () => {
 
   const root = {};
 
@@ -146,7 +146,7 @@ readline.createInterface({
       } else if (next.length > 0) {
         container[src.key] = next[0];
       } else {
-        container[src.key] = {}
+        container[src.key] = {};
       }
     }
     src.children.forEach(child => {


### PR DESCRIPTION
多くの人が開発に参加することを見込み，スタイルを統一し可読性の高いコードを保つために ESLint を導入した．

ESLint の選定は，

* ルールの拡張がしやすく公式ドキュメントが充実している
* 人気が高く公式以外の情報も多い

といった理由による．
cf. https://trends.google.co.jp/trends/explore?geo=JP&q=jslint,jshint,eslint
