### PR TITLE
test/test-bangou.js を修正

### DIFF
--- a/test/test-bangou.js
+++ b/test/test-bangou.js
@@ -1,5 +1,5 @@
 const bangou = require("../lib/bangou");
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
 const data = {
   "": {},
@@ -14,91 +14,114 @@ const data = {
   }
 };
 
-describe('imi-enrichment-address#bangou', function() {
-  describe('番地・号なし', function() {
-    it("空白", () => {
-      expect(bangou("")).deep.equal({});
-    });
-    it("数字以外で始まる文字列", () => {
-      expect(bangou("ビル名")).deep.equal({});
-    });
-  });
-  describe('番地のみ', function() {
-    it("半角", () => {
-      expect(bangou("12345")).deep.equal({
-        "番地": "12345"
-      });
-      expect(bangou("12345番")).deep.equal({
-        "番地": "12345"
-      });
-      expect(bangou("12345番地")).deep.equal({
-        "番地": "12345"
+describe("imi-enrichment-address#bangou", function () {
+  describe("番地、号を含まない文字列を変換するとき", function () {
+    describe("空白の文字列を変換するとき", () => {
+      it("空のオブジェクトを返す", () => {
+        expect(bangou("")).deep.equal({});
       });
     });
-    it("全角", () => {
-      expect(bangou("１２３４５")).deep.equal({
-        "番地": "12345"
-      });
-      expect(bangou("１２３４５番")).deep.equal({
-        "番地": "12345"
-      });
-      expect(bangou("１２３４５番地")).deep.equal({
-        "番地": "12345"
-      });
-    });
-    it("漢数字", () => {
-      expect(bangou("一〇三四五")).deep.equal({
-        "番地": "10345"
-      });
-      expect(bangou("一〇三四五番")).deep.equal({
-        "番地": "10345"
-      });
-      expect(bangou("一〇三四五番地")).deep.equal({
-        "番地": "10345"
+
+    describe("数字以外で始まる文字列を変換するとき", () => {
+      it("空のオブジェクトを返す", () => {
+        expect(bangou("ビル名")).deep.equal({});
       });
     });
   });
-  describe('番地号', function() {
-    it("半角", () => {
-      expect(bangou("103-45")).deep.equal({
-        "番地": "103",
-        "号": "45"
-      });
-      expect(bangou("103番45号")).deep.equal({
-        "番地": "103",
-        "号": "45"
-      });
-      expect(bangou("103番地45号")).deep.equal({
-        "番地": "103",
-        "号": "45"
-      });
-    });
-    it("全角", () => {
-      expect(bangou("１０３－４５")).deep.equal({
-        "番地": "103",
-        "号": "45"
-      });
-      expect(bangou("１０３番４５号")).deep.equal({
-        "番地": "103",
-        "号": "45"
-      });
-      expect(bangou("１０３番地４５号")).deep.equal({
-        "番地": "103",
-        "号": "45"
+
+  describe("番地のみを含む文字列を変換するとき", function () {
+    describe("番地が半角数字で表されているとき", () => {
+      it("番地を property にもち，値が半角数字の文字列であるオブジェクトを返す", () => {
+        expect(bangou("12345")).deep.equal({
+          "番地": "12345"
+        });
+        expect(bangou("12345番")).deep.equal({
+          "番地": "12345"
+        });
+        expect(bangou("12345番地")).deep.equal({
+          "番地": "12345"
+        });
       });
     });
-    it("漢数字", () => {
-      expect(bangou("一〇三－四五")).deep.equal({
-        "番地": "103",
-        "号": "45"
+
+    describe("番地が全角数字で表されているとき", () => {
+      it("番地を property にもち，値が半角数字の文字列であるオブジェクトを返す", () => {
+        expect(bangou("１２３４５")).deep.equal({
+          "番地": "12345"
+        });
+        expect(bangou("１２３４５番")).deep.equal({
+          "番地": "12345"
+        });
+        expect(bangou("１２３４５番地")).deep.equal({
+          "番地": "12345"
+        });
       });
-      expect(bangou("一〇三番四五号")).deep.equal({
-        "番地": "103",
-        "号": "45"
+    });
+
+    describe("番地が漢数字で表されているとき", () => {
+      it("番地を property にもち，値が半角数字の文字列であるオブジェクトを返す", () => {
+        expect(bangou("一〇三四五")).deep.equal({
+          "番地": "10345"
+        });
+        expect(bangou("一〇三四五番")).deep.equal({
+          "番地": "10345"
+        });
+        expect(bangou("一〇三四五番地")).deep.equal({
+          "番地": "10345"
+        });
       });
-      expect(bangou("一〇三番地四五号")).deep.equal({
-        "番地": "103",
-        "号": "45"
+    });
+  });
+
+  describe("番地、号を含む文字列を変換するとき", function () {
+    describe("番地、号が半角数字で表されているとき", () => {
+      it("番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す", () => {
+        expect(bangou("103-45")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+        expect(bangou("103番45号")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+        expect(bangou("103番地45号")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+      });
+    });
+
+    describe("番地が全角数字で表されているとき", () => {
+      it("番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す", () => {
+        expect(bangou("１０３－４５")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+        expect(bangou("１０３番４５号")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+        expect(bangou("１０３番地４５号")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+      });
+    });
+
+    describe("番地が漢数字で表されているとき", () => {
+      it("番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す", () => {
+        expect(bangou("一〇三－四五")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+        expect(bangou("一〇三番四五号")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
+        expect(bangou("一〇三番地四五号")).deep.equal({
+          "番地": "103",
+          "号": "45"
+        });
       });
     });
   });

--- a/test/test-bangou.js
+++ b/test/test-bangou.js
@@ -1,8 +1,8 @@
 const bangou = require("../lib/bangou");
 const expect = require("chai").expect;
 
-describe("imi-enrichment-address#bangou", function () {
-  describe("番地、号を含まない文字列を変換するとき", function () {
+describe("imi-enrichment-address#bangou", () => {
+  describe("番地、号を含まない文字列を変換するとき", () => {
     describe("空白の文字列を変換するとき", () => {
       it("空のオブジェクトを返す", () => {
         expect(bangou("")).deep.equal({});
@@ -16,7 +16,7 @@ describe("imi-enrichment-address#bangou", function () {
     });
   });
 
-  describe("番地のみを含む文字列を変換するとき", function () {
+  describe("番地のみを含む文字列を変換するとき", () => {
     describe("番地が半角数字で表されているとき", () => {
       it("番地を property にもち，値が半角数字の文字列であるオブジェクトを返す", () => {
         expect(bangou("12345")).deep.equal({
@@ -60,7 +60,7 @@ describe("imi-enrichment-address#bangou", function () {
     });
   });
 
-  describe("番地、号を含む文字列を変換するとき", function () {
+  describe("番地、号を含む文字列を変換するとき", () => {
     describe("番地、号が半角数字で表されているとき", () => {
       it("番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す", () => {
         expect(bangou("103-45")).deep.equal({

--- a/test/test-bangou.js
+++ b/test/test-bangou.js
@@ -1,19 +1,6 @@
 const bangou = require("../lib/bangou");
 const expect = require("chai").expect;
 
-const data = {
-  "": {},
-  "ビル名": {},
-  "1-2": {
-    "番地": "1",
-    "号": "2"
-  },
-  "1-2": {
-    "番地": "1",
-    "号": "2"
-  }
-};
-
 describe("imi-enrichment-address#bangou", function () {
   describe("番地、号を含まない文字列を変換するとき", function () {
     describe("空白の文字列を変換するとき", () => {


### PR DESCRIPTION
テストコードやテスト実行時の表示を読んでもテストの意図や本体のコードの仕様が理解しづらい上，`describe` と `it` の使い分けができておらず，テストの品質が低いと思われたため，修正した．

## mocha 実行時の表示内容の比較

### 修正前

```
  imi-enrichment-address#bangou
    番地・号なし
      ✓ 空白
      ✓ 数字以外で始まる文字列
    番地のみ
      ✓ 半角
      ✓ 全角
      ✓ 漢数字
    番地号
      ✓ 半角
      ✓ 全角
      ✓ 漢数字
```

### 修正後

```
  imi-enrichment-address#bangou
    番地、号を含まない文字列を変換するとき
      空白の文字列を変換するとき
        ✓ 空のオブジェクトを返す
      数字以外で始まる文字列を変換するとき
        ✓ 空のオブジェクトを返す
    番地のみを含む文字列を変換するとき
      番地が半角数字で表されているとき
        ✓ 番地を property にもち，値が半角数字の文字列であるオブジェクトを返す
      番地が全角数字で表されているとき
        ✓ 番地を property にもち，値が半角数字の文字列であるオブジェクトを返す
      番地が漢数字で表されているとき
        ✓ 番地を property にもち，値が半角数字の文字列であるオブジェクトを返す
    番地、号を含む文字列を変換するとき
      番地、号が半角数字で表されているとき
        ✓ 番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す
      番地が全角数字で表されているとき
        ✓ 番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す
      番地が漢数字で表されているとき
        ✓ 番地、号を property にもち，それぞれの値が半角数字の文字列であるオブジェクトを返す
```
