### PR TITLE
Fix build problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+cache
+db

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -12,7 +12,7 @@ mkdir -p ${CACHE_DIR}
 rm -f ${OUTPUT}
 
 for no in `seq -w 1000 1000 47000` ; do
-  url="http://nlftp.mlit.go.jp/isj/dls/data/12.0b/${no}-12.0b.zip"
+  url="https://nlftp.mlit.go.jp/isj/dls/data/12.0b/${no}-12.0b.zip"
   zip=${CACHE_DIR}/${no}.zip
   if [ ! -e "${zip}" ] ; then
     curl $url > ${zip}


### PR DESCRIPTION
位置参照情報のサイトリニューアルに伴い、従来の HTTP の URL が 404 Not Found を返してダウンロードに失敗、
ビルドが頓挫するという問題がありました。
ダウンロード先をリニューアル後の HTTPS の URL に変更することで最後までビルド＆テストできるように修正したものです。
なおビルド中に生成される cache フォルダおよび db フォルダはそれぞれ一時ファイル／データベースバイナリであるため、 
git 管理外とするのが妥当です。そのため、 .gitignore に cache/db を追加する更新も含んでいます。